### PR TITLE
Added missing tr binary

### DIFF
--- a/res/arch/tpm2clevis/initcpio/install/mortar
+++ b/res/arch/tpm2clevis/initcpio/install/mortar
@@ -21,6 +21,7 @@ build() {
     add_binary "jose"
     add_binary "curl"
     add_binary "bash"
+    add_binary "tr"
     #Future-proofing for tpm2-tools v4
     tpm2_pcrget_bin=$(command -v tpm2_pcrlist)
     if [ -z "$tpm2_pcrget_bin" ]; then tpm2_pcrget_bin=$(command -v tpm2_pcrread); fi


### PR DESCRIPTION
Notwithstanding #9, the Arch mortar initcpio hook is missing `tr`, which causes the verification process to fail on TPM2.