### PR TITLE
Condense luk passwords to one entry for 3-tpm1.2 and 3-tpm2

### DIFF
--- a/3-tpm1.2-prepluksandinstallhooks.sh
+++ b/3-tpm1.2-prepluksandinstallhooks.sh
@@ -17,7 +17,7 @@ fi
 
 
 #Create tpmramfs for generated mortar key and read user luks password to file.
-if [ mkdir tmpramfs; mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs ]; then
+if mkdir tmpramfs; mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs; then
 	echo "Created tmpfs to store luks keys."
 	echo -n "Enter luks password: "; read -s PASSWORD; echo
 	echo -n $PASSWORD > tmpramfs/user.key
@@ -27,7 +27,7 @@ else
 	exit 1
 fi
 
-if [ command -v luksmeta >/dev/null ]; then
+if command -v luksmeta >/dev/null; then
 	echo "Wiping any existing metadata in the luks keyslot."
 	luksmeta wipe -d "$CRYPTDEV" -s "$SLOT"
 fi
@@ -51,11 +51,11 @@ if [ -d tmpramfs ]; then
 	PERMISSIONS="OWNERWRITE|READ_STCLEAR"
 	read -s -r -p "Owner password: " OWNERPW
 	# Wipe index if it is populated.
-	if [ tpm_nvinfo | grep \($TPMINDEX\) > /dev/null ]; then tpm_nvrelease -i "$TPMINDEX" -o"$OWNERPW"; fi
+	if tpm_nvinfo | grep \($TPMINDEX\) > /dev/null; then tpm_nvrelease -i "$TPMINDEX" -o"$OWNERPW"; fi
 	# Convert PCR format...
 	PCRS=$(echo "-r""$BINDPCR" | sed 's/,/ -r/g')
 	# Create new index sealed to PCRS. 
-	if [ tpm_nvdefine -i "$TPMINDEX" -s $(wc -c tmpramfs/mortar.key) -p "$PERMISSIONS" -o "$OWNERPW" -z $PCRS ]; then
+	if tpm_nvdefine -i "$TPMINDEX" -s $(wc -c tmpramfs/mortar.key) -p "$PERMISSIONS" -o "$OWNERPW" -z $PCRS; then
 		# Write key into the index...
 		tpm_nvwrite -i "$TPMINDEX" -f tmpramfs/mortar.key -z --password="$OWNERPW"
 	fi

--- a/3-tpm1.2-prepluksandinstallhooks.sh
+++ b/3-tpm1.2-prepluksandinstallhooks.sh
@@ -18,6 +18,7 @@ fi
 #Create tpmramfs for generated mortar key and read user luks password to file.
 if mkdir tmpramfs && mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs; then
 	echo "Created tmpramfs for storing the key."
+	trap "if [ -f tmpramfs/user.key ]; then rm -f tmpramfs/user.key; fi" EXIT
 	echo -n "Enter luks password: "; read -s PASSWORD; echo
 	echo -n "$PASSWORD" > tmpramfs/user.key
 	unset PASSWORD

--- a/3-tpm2clevis-prepluksandinstallhooks.sh
+++ b/3-tpm2clevis-prepluksandinstallhooks.sh
@@ -26,6 +26,7 @@ fi
 #Create tpmramfs for read user luks password to file.
 if mkdir tmpramfs && mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs; then
 	echo "Created tmpramfs to store luks key during setup."
+	trap "if [ -f tmpramfs/user.key ]; then rm -f tmpramfs/user.key; fi" EXIT
 	echo -n "Enter luks password: "; read -s PASSWORD; echo
 	echo -n "$PASSWORD" > tmpramfs/user.key
 	unset PASSWORD

--- a/3-tpm2clevis-prepluksandinstallhooks.sh
+++ b/3-tpm2clevis-prepluksandinstallhooks.sh
@@ -17,14 +17,14 @@ if [ -z "$LUKSVER" ]; then
 fi
 
 #Remove tpmfs from failed runs if applicable.
-if [[ -d tmpramfs ]]; then
+if [ -d tmpramfs ]; then
 	echo "Removing existing tmpramfs..."
 	umount tmpramfs
 	rm -r tmpramfs
 fi
 
 #Create tpmramfs for read user luks password to file.
-if (mkdir tmpramfs && mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs); then
+if [ mkdir tmpramfs; mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs ]; then
 	echo "Created tmpfs to store luks keys."
 	echo -n "Enter luks password: "
 	read -s PASSWORD

--- a/3-tpm2clevis-prepluksandinstallhooks.sh
+++ b/3-tpm2clevis-prepluksandinstallhooks.sh
@@ -24,11 +24,9 @@ if [ -d tmpramfs ]; then
 fi
 
 #Create tpmramfs for read user luks password to file.
-if [ mkdir tmpramfs; mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs ]; then
+if mkdir tmpramfs; mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs; then
 	echo "Created tmpfs to store luks keys."
-	echo -n "Enter luks password: "
-	read -s PASSWORD
-	echo
+	echo -n "Enter luks password: "; read -s PASSWORD; echo
 	echo -n $PASSWORD > tmpramfs/user.key
 	unset PASSWORD	
 else

--- a/3-tpm2clevis-prepluksandinstallhooks.sh
+++ b/3-tpm2clevis-prepluksandinstallhooks.sh
@@ -47,10 +47,10 @@ if [ "$LUKSVER" == "2" ]; then
 fi
 
 
-echo "Wiping any old luks key in the keyslot. (You'll need to enter a password.)"
+echo "Wiping any old luks key in the keyslot."
 cryptsetup luksKillSlot --key-file tmpramfs/user.key "$CRYPTDEV" "$SLOT" 
 echo "Generating clevis key, adding it to the luks slot, and mapping it to the TPM PCRs."
-clevis-luks-bind -d "$CRYPTDEV" -s "$SLOT" tpm2 '{"pcr_bank":"'"$TPMHASHTYPE"'","pcr_ids":"'"$BINDPCR"'"}' -k tmpramfs/user.key
+clevis-luks-bind -d "$CRYPTDEV" -k tmpramfs/user.key -s "$SLOT" tpm2 '{"pcr_bank":"'"$TPMHASHTYPE"'","pcr_ids":"'"$BINDPCR"'"}'
 echo "Wiping keys and unmounting tmpramfs."
 rm tmpramfs/user.key
 umount -l tmpramfs


### PR DESCRIPTION
tmpramfs is initialized early in the script. `read -s` is used to temporarily store password to a shell variable than write to user.key in tmpramfs. Bash variable is then unset and user.key is supplied to `cryptsetup --key-file` and `clevis-luks-bind -k`. Files are removed after tpm key is sealed and tmpramfs unmounted. 

Slight error detection changes. 

I have not been able to test the tpm2 script because my laptop only functions in tpm1.2 mode but that's why it's a separate commit. It should work considering the only significant difference between the two is the `clevis-luks-bind -k` command. 

Aside: Would shred -u be a better option than rm for removing keyfiles from tmpfs?