### PR TITLE
Add support for signing DKMS modules with db.key to Ubuntu and Debian

### DIFF
--- a/chain-sign-hook.conf
+++ b/chain-sign-hook.conf
@@ -1,0 +1,129 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154
+
+# determine relative postfix required to discard path prepended by DKMS framework
+# script path composed like
+# run="$dkms_tree/$module/$module_version/$script_type/$2"
+
+
+root_relative_path=""
+
+while [[ "$(realpath "$dkms_tree/$root_relative_path")" != '/' ]] ; do
+    root_relative_path="${root_relative_path}../"
+done
+root_relative_path="${root_relative_path}../../../"
+
+# get original post-build script path
+orig_post_build="$POST_BUILD"
+
+# preview some variables inferred by DKMS
+array_size=0
+for s in ${#BUILT_MODULE_NAME[@]} \
+    ${#BUILT_MODULE_LOCATION[@]} \
+    ${#DEST_MODULE_NAME[@]} \
+    ${#DEST_MODULE_LOCATION[@]}; do
+    ((s > array_size)) && array_size=$s
+done
+
+for ((index=0; index < array_size; index++)); do
+    built_module_name[$index]=${BUILT_MODULE_NAME[$index]}
+    built_module_location[$index]=${BUILT_MODULE_LOCATION[$index]}
+    dest_module_name[$index]=${DEST_MODULE_NAME[$index]}
+    dest_module_location[$index]=${DEST_MODULE_LOCATION[$index]}
+
+    [[ ! ${built_module_name[$index]} ]] && \
+        ((${#DEST_MODULE_LOCATION[@]} == 1)) && \
+        built_module_name[$index]=$module
+    [[ ! ${dest_module_name[$index]} ]] && \
+        dest_module_name[$index]=${built_module_name[$index]}
+    [[ ${built_module_location[$index]} && \
+        ${built_module_location[$index]:(-1)} != / ]] && \
+        built_module_location[$index]="${built_module_location[$index]}/"
+
+    dest_module_location[$index]="$(override_dest_module_location ${dest_module_location[$index]})"
+done
+
+# force strip to remove foreign signatures
+for ((index=0; index < array_size; index++)); do
+    STRIP[$index]=Y
+done
+
+# discover module suffix
+set_module_suffix "$kernelver"
+base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
+
+# make temporary file with script performing required actions and passing
+# control to original POST_BUILD script
+tmpscript="$(mktemp)"
+cat > "$tmpscript" << EOF
+#!/bin/bash
+
+rm -f "$tmpscript"
+
+orig_post_build="$orig_post_build"
+run="$dkms_tree/$module/$module_version/build/$orig_post_build"
+
+if [[ \$orig_post_build ]] ; then
+    if [[ -x \${run%% *} ]]; then
+        \$run
+    else
+        >&2 echo "The \$orig_post_build script is not executable."
+    fi
+fi
+
+EOF
+
+for ((count=0; count < ${#built_module_name[@]}; count++)); do
+if [ "$module_compressed_suffix" = ".gz" ]; then
+    cat >> "$tmpscript" << EOF
+    gunzip -f "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_suffix"
+    "$kernel_source_dir/scripts/sign-file" sha256 /etc/mortar/private/db.key /etc/mortar/private/db.crt.der "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_uncompressed_suffix"
+    gzip -9f "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_uncompressed_suffix"
+EOF
+elif [ "$module_compressed_suffix" = ".xz" ]; then
+    cat >> "$tmpscript" << EOF
+unxz -f "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_suffix"
+"$kernel_source_dir/scripts/sign-file" sha256 /etc/mortar/private/db.key /etc/mortar/private/db.crt.der "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_uncompressed_suffix"
+xz -f "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_uncompressed_suffix"
+EOF
+else
+    cat >> "$tmpscript" << EOF
+"$kernel_source_dir/scripts/sign-file" sha256 /etc/mortar/private/db.key /etc/mortar/private/db.crt.der "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_suffix"
+EOF
+fi
+
+# Copy module again, with signature
+cat >> "$tmpscript" << EOF
+cp -f "$dkms_tree/$module/$module_version/build/${built_module_location[$count]}${built_module_name[$count]}$module_suffix" "$base_dir/module/${dest_module_name[$count]}$module_suffix" >/dev/null
+EOF
+done
+
+chmod +x "$tmpscript"
+
+POST_BUILD="${root_relative_path}${tmpscript}"
+
+# supress DKMS signature mechanism on Ubuntu.
+# $tmpfile is a file which is used by DKMS to source this config safely.
+if type sign_build >/dev/null 2>&1 ; then
+    if [[ "$tmpfile" ]] && [[ "${export_envs+x}" ]] && \
+    [[ $_ != $0 ]] && (( $$ != BASHPID )) ; then
+        # matched safe_source environment
+    
+        cat >> "$tmpfile" << EOF
+unset sign_build
+sign_build () { :; }
+EOF
+    
+        exec >>"$tmpfile"
+        for _export_env in "${export_envs[@]}"; do
+            for _i in $(eval echo \${!$_export_env[@]}); do
+                eval echo '$_export_env[$_i]=\"${'$_export_env'[$_i]}\"'
+            done
+        done
+        exit 0
+    else
+        # safe_source condition doesn't match. probably it's a direct source
+        unset sign_build
+        sign_build () { :; }
+    fi
+fi

--- a/res/debian/tpm1.2/install.sh
+++ b/res/debian/tpm1.2/install.sh
@@ -6,6 +6,10 @@ cp -r kernel /etc/
 
 # Install the initramfs script and update hook. 
 cp -r initramfs-tools /etc/
+
+# Install DKMS hook for module signing using /etc/mortar/private/db.key and db.crt.der
+cp ../../../chain-sign-hook.conf /var/lib/secureboot/dkms/
+
 INITRAMFSSCRIPTFILE='/etc/initramfs-tools/scripts/local-top/mortar'
 source /etc/mortar/mortar.env
 sed -i -e "/^CRYPTDEV=.*/{s##CRYPTDEV=\"$CRYPTDEV\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
@@ -15,6 +19,7 @@ sed -i -e "/^TPMINDEX=.*/{s//TPMINDEX=$TPMINDEX/;:a" -e '$!N;$!b' -e '}' "$INITR
 sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^HEADERFILE=.*/{s##HEADERFILE=\"$HEADERFILE\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 
+bash /opt/mortar/setup-dkms.sh
 update-initramfs -u
 
 echo "Initramfs updated. You need to run mortar-compilesigninstall [kernelpath] [initramfspath]"

--- a/res/debian/tpm2clevis/install.sh
+++ b/res/debian/tpm2clevis/install.sh
@@ -6,6 +6,10 @@ cp -r kernel /etc/
 
 # Install the initramfs script and update hook. 
 cp -r initramfs-tools /etc/
+
+# Install DKMS hook for module signing using /etc/mortar/private/db.key and db.crt.der
+cp  ../../../chain-sign-hook.conf /var/lib/secureboot/dkms/
+
 INITRAMFSSCRIPTFILE='/etc/initramfs-tools/scripts/local-top/mortar'
 if ! [ "$1" == "nosource" ]; then source /etc/mortar/mortar.env; fi
 sed -i -e "/^CRYPTDEV=.*/{s##CRYPTDEV=\"$CRYPTDEV\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
@@ -16,6 +20,7 @@ sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e
 sed -i -e "/^HEADERFILE=.*/{s##HEADERFILE=\"$HEADERFILE\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^TOKENID=.*/{s//TOKENID=$TOKENID/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 
+bash /opt/mortar/setup-dkms.sh
 update-initramfs -u
 
 echo "Initramfs updated. You need to run mortar-compilesigninstall [kernelpath] [initramfspath]"

--- a/res/ubuntu/tpm1.2/install.sh
+++ b/res/ubuntu/tpm1.2/install.sh
@@ -6,6 +6,10 @@ cp -r kernel /etc/
 
 # Install the initramfs script and update hook. 
 cp -r initramfs-tools /etc/
+
+# Install DKMS hook for module signing using /etc/mortar/private/db.key and db.crt.der
+cp ../../../chain-sign-hook.conf /var/lib/secureboot/dkms/
+
 INITRAMFSSCRIPTFILE='/etc/initramfs-tools/scripts/local-top/mortar'
 source /etc/mortar/mortar.env
 sed -i -e "/^CRYPTDEV=.*/{s##CRYPTDEV=\"$CRYPTDEV\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
@@ -15,6 +19,7 @@ sed -i -e "/^TPMINDEX=.*/{s//TPMINDEX=$TPMINDEX/;:a" -e '$!N;$!b' -e '}' "$INITR
 sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^HEADERFILE=.*/{s##HEADERFILE=\"$HEADERFILE\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 
+bash /opt/mortar/setup-dkms.sh
 update-initramfs -u
 
 echo "Initramfs updated. You need to run mortar-compilesigninstall [kernelpath] [initramfspath]"

--- a/res/ubuntu/tpm2clevis/install.sh
+++ b/res/ubuntu/tpm2clevis/install.sh
@@ -6,6 +6,10 @@ cp -r kernel /etc/
 
 # Install the initramfs script and update hook. 
 cp -r initramfs-tools /etc/
+
+# Install DKMS hook for module signing using /etc/mortar/private/db.key and db.crt.der
+cp ../../../chain-sign-hook.conf /var/lib/secureboot/dkms/
+
 INITRAMFSSCRIPTFILE='/etc/initramfs-tools/scripts/local-top/mortar'
 if ! [ "$1" == "nosource" ]; then source /etc/mortar/mortar.env; fi
 sed -i -e "/^CRYPTDEV=.*/{s##CRYPTDEV=\"$CRYPTDEV\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
@@ -16,6 +20,7 @@ sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e
 sed -i -e "/^HEADERFILE=.*/{s##HEADERFILE=\"$HEADERFILE\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^TOKENID=.*/{s//TOKENID=$TOKENID/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 
+bash /opt/mortar/setup-dkms.sh
 update-initramfs -u
 
 echo "Initramfs updated. You need to run mortar-compilesigninstall [kernelpath] [initramfspath]"

--- a/setup-dkms.sh
+++ b/setup-dkms.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+if ! { [[ -d /etc/dkms ]] && [[ -x "$(command -v dkms)" ]] && \
+[[ -r /etc/dkms/framework.conf ]] ; } ; then
+    >&2 echo "No working installation of DKMS framework found. Skipping setup."
+    exit 0
+fi
+
+hook_script="/var/lib/secureboot/dkms/chain-sign-hook.conf"
+[[ -e "$hook_script" ]] || {
+    >&2 echo "Hook script is not installed!"
+    exit 1
+}
+
+dkms_tree="/var/lib/dkms"
+. /etc/dkms/framework.conf
+
+dkms_status="$(dkms status)"
+
+# parse dkms status
+shopt -s extglob
+i=0
+while read -r line ; do
+    IFS=',' read -ra arr <<< "$line"
+    module[$i]="${arr[0]}"
+    version[$i]="${arr[1]##+([[:space:]])}"
+    kernelver[$i]="${arr[2]##+([[:space:]])}"
+    arch_status="${arr[3]##+([[:space:]])}"
+    IFS=':' read -ra arch_status_arr <<< "$arch_status"
+    arch[$i]="${arch_status_arr[0]}"
+    status[$i]="${arch_status_arr[1]##+([[:space:]])}"
+    [[ "${module[$i]}" ]] && [[ "${version[$i]}" ]] && [[ "${kernelver[$i]}" ]] \
+    && [[ "${arch[$i]}" ]] && [[ "${#arr[@]}" = 4 ]] && \
+    [[ "${#arch_status_arr[@]}" = 2 ]] && [[ "${status[$i]}" =~ installed ]] && \
+        (( i++ ))
+done <<< "$dkms_status"
+
+mod_count="$i"
+
+flagdir="$(mktemp -d)"
+cleanup () {
+    rm -rf "$flagdir"
+}
+trap cleanup EXIT
+
+# install hooks for modules
+for ((i=0; i<mod_count; i++)) ; do
+    modconf="/etc/dkms/${module[$i]}.conf"
+    if [[ -e "$flagdir/${module[$i]}.conf_installed" ]] ; then
+        continue
+    else
+        if [[ -e "$modconf" ]] || [[ -h "$modconf" ]] ; then
+            if [[ -e "$flagdir/${module[$i]}.merge_notify" ]] ; then
+                continue
+            else
+                >&2 echo "Module ${module[$i]} already has user override."
+                >&2 echo "Please do manual merge with $hook_script."
+                :> "$flagdir/${module[$i]}.merge_notify"
+            fi
+        else
+            ln -s "$hook_script" "$modconf"
+            :> "$flagdir/${module[$i]}.conf_installed"
+        fi
+    fi
+done
+
+# rebuild all modules one by one
+for ((i=0; i<mod_count; i++)) ; do
+    [[ -e "$flagdir/${module[$i]}.conf_installed" ]] || continue
+    >&2 echo "rebuilding module='${module[$i]}' version='${version[$i]}'" \
+    "kernelver='${kernelver[$i]}' arch='${arch[$i]}'"
+    dkms uninstall -m "${module[$i]}" -v "${version[$i]}" -k "${kernelver[$i]}" -a "${arch[$i]}"
+    # clean build artifacts to ensure rebuild will take place
+    rm -rf "${dkms_tree:?}/${module[$i]}/${version[$i]}/${kernelver[$i]}/${arch[$i]}/"
+    dkms install -m "${module[$i]}" -v "${version[$i]}" -k "${kernelver[$i]}" -a "${arch[$i]}"
+done
+
+# cleanup
+exit 0


### PR DESCRIPTION
This functionality uses two files taken from https://github.com/Snawoot/linux-secureboot-kit, setup-dkms.sh and chain-sign-hook.conf.
The DKMS signing hook is copied to the system at /var/lib/secureboot/dkms and setup-dkms.sh is ran by the install.sh. 
Setup-dkms.sh will sign all current DKMS modules with /etc/mortar/private/db.key (My logic on this is hardcoded. Mok could be used but I don't think my systemd-boot supports MOK.) and setup signing for future DKMS module installs. 
This fixes programs like Virtualbox and Anbox being unable to run. 
This may work for CentOS and Arch too. 
One small annoyance, if you have to rerun the 3. script and already setup DKMS, you'll get a bunch of spam messages in your terminal. Setup-dkms really only needs to be ran once. It could be included in the root as an optional step. 