### PR TITLE
decrypt multiple devices on boot

### DIFF
--- a/1-generatesecurebootkeys.sh
+++ b/1-generatesecurebootkeys.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
-source mortar.env
+MORTAR_FILE="/etc/mortar/mortar.env"
+source "$MORTAR_FILE"
 echo "Generating secureboot keys..."
 openssl req -new -x509 -newkey rsa:2048 -subj "/CN=PK$SECUREBOOT_MODIFIER/"  -keyout "$SECUREBOOT_PK_KEY"  -out "$SECUREBOOT_PK_CRT"  -days 7300 -nodes -sha256
 openssl req -new -x509 -newkey rsa:2048 -subj "/CN=KEK$SECUREBOOT_MODIFIER/" -keyout "$SECUREBOOT_KEK_KEY" -out "$SECUREBOOT_KEK_CRT" -days 7300 -nodes -sha256

--- a/3-tpm1.2-prepluksandinstallhooks.sh
+++ b/3-tpm1.2-prepluksandinstallhooks.sh
@@ -79,8 +79,6 @@ umount -l tmpramfs
 rm -rf tmpramfs
 
 echo "Adding new sha256 of the luks header to the mortar env file."
-if [ -f "$HEADERFILE" ]; then rm "$HEADERFILE"; fi
-cryptsetup luksHeaderBackup "$CRYPTDEV" --header-backup-file "$HEADERFILE"
 HEADERSHA256=""
 for CRYPTNAME in $CRYPTNAMES; do
   CRYPTDEV="$(cryptnametodevice $CRYPTNAME)"

--- a/mortar.env
+++ b/mortar.env
@@ -57,9 +57,12 @@ SECUREBOOT_KEK_KEY=$PRIVATE_DIR'KEK.key'
 
 # Stage 3.
 #LUKS Partition as named in the crypttab, space separated for multiple disks
-#like: CRYPTNAMES="disk1 disk2" if your crypttab shows for example:
-#disk1 UUID=32280417-d1e9-4e36-8c8b-ee2b87f31c31 none initramfs,luks,discard
-#disk2 /dev/sda2 none initramfs,luks,discard
+#if your crypttab shows for example:
+# disk1 UUID=32280417-d1e9-4e36-8c8b-ee2b87f31c31 none initramfs,luks,discard
+# disk2 /dev/sda2 none initramfs,luks,discard
+#and you want to decode both disk1 and disk2 inside the initrd via tpm key, 
+#then the line would be:
+# CRYPTNAMES="disk1 disk2" 
 #you do need to name only disks which should get decrypted by mortar
 CRYPTNAMES=""
 if [ -z "$CRYPTNAMES" ]; then echo "CRYPTNAMES must be specified"; exit 1; fi

--- a/mortar.env
+++ b/mortar.env
@@ -20,7 +20,7 @@ cd "$WORKING_DIR"
 function cryptnametodevice {
   DEVICE=$(grep "^[^#;]" /etc/crypttab | grep "$1" | awk '{ print $2 }')
   if [ -z $DEVICE ]; then
-    echo "ERROR: cannot find CRYPTDEV for CRYPTNAME"
+    echo "ERROR: cannot find CRYPTDEV for CRYPTNAME $1"
     exit 1
   fi
   echo $DEVICE

--- a/mortar.env
+++ b/mortar.env
@@ -57,10 +57,13 @@ SECUREBOOT_KEK_AUTH=$PRIVATE_DIR'KEK.auth'
 SECUREBOOT_KEK_KEY=$PRIVATE_DIR'KEK.key'
 
 # Stage 3.
-CRYPTDEV= #LUKS Partition e.g. /dev/nvme0n1p3 next line will give it the old college try if this is left blank. 
-if [ -z "$CRYPTDEV" ]; then temp=$(grep "^[^#;]" /etc/crypttab | head -n1 | awk '{ print $2 }'); if [ -e "$temp" ]; then CRYPTDEV="$temp"; else if [[ "$temp" == "UUID="* ]]; then temp=$(echo "$temp" | cut -f2 -d'='); CRYPTDEV="/dev/disk/by-uuid/$temp"; unset temp; fi; fi; fi
-CRYPTNAME= #Unlocked name (find in crypttab) e.g. luks-disk next line will give it the old college try if this is left blank.
-if [ -z "$CRYPTNAME" ]; then CRYPTNAME=$(grep -v "^#" /etc/crypttab | head -n1 | awk '{ print $1 }'); fi
+#LUKS Partition as named in the crypttab, space separated for multiple disks
+#like: CRYPTNAMES="disk1 disk2" if your crypttab shows for example:
+#disk1 UUID=32280417-d1e9-4e36-8c8b-ee2b87f31c31 none initramfs,luks,discard
+#disk2 /dev/sda2 none initramfs,luks,discard
+#you do need to name only disks which should get decrypted by mortar
+CRYPTNAMES=""
+if [ -z "$CRYPTNAMES" ]; then echo "CRYPTNAMES must be specified"; exit 1; fi
 LUKSVER= #1 or 2 - best effort will be given if left blank.
 SLOT="1" # LUKS keyslot number for use with automatic unlocks. 
 # Only used for LUKS1: UUID OF THE KEYSLOT, NOT THE DISK. Find with `luksmeta show -d /dev/nvmluks0p3` and check the slot uuid. Logic exists in the luks setup script if this is left blank. (hence why this comment is on a different line).

--- a/mortar.env
+++ b/mortar.env
@@ -4,8 +4,7 @@ PRIVATE_DIR="$WORKING_DIR"'private/'
 # Note to reader: Most of these values can be left as-is. Some have good defaults or are auto-populated as part of the other scripts.  
 # You should, however specifically review or statically set (the CRYPTNAME auto logic is particularly weak, but getting better):  
 # EFI_ROOT
-# CRYPTDEV
-# CRYPTNAME
+# CRYPTNAMES
 # SLOT
 # TPMINDEX
 # BINDPCR
@@ -68,6 +67,7 @@ LUKSVER= #1 or 2 - best effort will be given if left blank.
 SLOT="1" # LUKS keyslot number for use with automatic unlocks. 
 # Only used for LUKS1: UUID OF THE KEYSLOT, NOT THE DISK. Find with `luksmeta show -d /dev/nvmluks0p3` and check the slot uuid. Logic exists in the luks setup script if this is left blank. (hence why this comment is on a different line).
 SLOTUUID=
+#TODO: finding TOKENIDs must get adapted for multiple CRYPTNAMES
 TOKENID= # Only used for LUKS2 - Token ID in luks header for clevis. Usually 0. Logic below attempts to find out if left blank.
 if [ -z "$TOKENID" ]; then TOKENID=$(cryptsetup luksDump "$CRYPTDEV" | grep clevis | sed -e 's/  \(.*\): clevis/\1/'); fi #clevis scripts used sed -rn 's|^\s+([0-9]+): clevis|\1|p' after the cryptsetup pipe. Maybe that is better? *shrug*
 # Only used for TPM 1.2 - NVRAM index number for storing LUKS key in TPM.

--- a/mortar.env
+++ b/mortar.env
@@ -10,7 +10,6 @@ PRIVATE_DIR="$WORKING_DIR"'private/'
 # TPMINDEX
 # BINDPCR
 
-
 # Permission checks.
 if [ "$UID" -ne "0" ]; then echo "Must be run as root."; exit 1; fi
 mkdir -p "$PRIVATE_DIR"
@@ -18,6 +17,15 @@ chown root:root -R "$PRIVATE_DIR"
 chmod go-rwx -R "$PRIVATE_DIR"
 chmod go-rwx -R "$WORKING_DIR"
 cd "$WORKING_DIR"
+
+function cryptnametodevice {
+  DEVICE=$(grep "^[^#;]" /etc/crypttab | grep "$1" | awk '{ print $2 }')
+  if [ -z $DEVICE ]; then
+    echo "ERROR: cannot find CRYPTDEV for CRYPTNAME"
+    exit 1
+  fi
+  echo $DEVICE
+}
 
 TPM_MODE= #1.2 or 2 - not yet used.
 # Stage 1.

--- a/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
+++ b/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
@@ -46,7 +46,13 @@ for CRYPTPAIR in $CRYPTPAIRS; do
 done
 
 # Get Mortar key.
-tpm_nvread -i "$TPMINDEX" -f /tmp/mortar.key >/dev/null
+if tpm_nvread -i "$TPMINDEX" -f /tmp/mortar.key >/dev/null; then
+ echo -e "TPM VALIDATION SUCCEEDED.\n\n"
+else
+ echo -e "TPM VALIDATION FAILED.\n\n"
+ sleep 3
+fi
+
 # Disable future key fetches.
 tcsd && sleep 1
 tpm_nvread -i "$TPMINDEX" -s 0 >> /dev/null

--- a/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
+++ b/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
@@ -57,7 +57,7 @@ fi
 tcsd && sleep 1
 tpm_nvread -i "$TPMINDEX" -s 0 >> /dev/null
 
-# Decrypt disk.
+# Decrypt disk(s).
 for CRYPTPAIR in $CRYPTPAIRS; do 
   CRYPTNAME=${CRYPTPAIR%:*}
   CRYPTDEV=${CRYPTPAIR#*:}

--- a/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
+++ b/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
@@ -14,36 +14,36 @@ mkdir -p /run/cryptsetup
 
 echo "Initializing... Please wait a few seconds for TPM validation of boot sequence."
 echo "Measuring boot system integrity..."
-CRYPTDEV= #LUKS Partition /dev/sda3
-CRYPTNAME= #Unlocked name (find in crypttab)
+CRYPTPAIRS= #name(s) of the unlocked device(s) (first row in crypttab)
 SLOT= #Keyslot number in use by mortar.
 TPMINDEX=
 HEADERSHA256=
 HEADERFILE=
 
-# Test if the disk is already unlocked.
-if [ -e /dev/mapper/"$CRYPTNAME" ]; then exit; fi
-if ! [ -e "$CRYPTDEV" ]; then echo "Cannot find the crypto block device at $CRYPTDEV"; exit 1; fi
-sleep 2
-if [ -f "$HEADERFILE" ]; then rm "$HEADERFILE"; fi
-if cryptsetup luksHeaderBackup "$CRYPTDEV" --header-backup-file "$HEADERFILE"; then
+for CRYPTPAIR in $CRYPTPAIRS; do 
+  CRYPTNAME=${CRYPTPAIR%:*}
+  CRYPTDEV=${CRYPTPAIR#*:}
+  if [ -f "$HEADERFILE" ]; then rm "$HEADERFILE"; fi
+  if cryptsetup luksHeaderBackup "$CRYPTDEV" --header-backup-file "$HEADERFILE"; then
     HEADERSHA256CUR=`sha256sum "$HEADERFILE" | cut -f1 -d' '`
-    if [ "$HEADERSHA256" == "$HEADERSHA256CUR" ]; then
-        echo "HEADER VALIDATION SUCCEEDED."
+    if test "${HEADERSHA256#*$HEADERSHA256CUR}" != "$HEADERSHA256"; then
+      echo "HEADER VALIDATION SUCCEEDED FOR $CRYPTNAME."
     else
-        echo "HEADER VALIDATION FAILED."
-	echo "WAITING 10 SECONDS BEFORE CONTINUING."
-	echo "KILL SYSTEM NOW IF YOU DO NOT TRUST THIS HEADER."
-	sleep 7
-	echo "3..."
-	sleep 1
-	echo "2..."
-	sleep 1
-	echo "1..."
-	sleep 1
+      echo "HEADER VALIDATION FAILED FOR $CRYPTNAME."
+      echo "WAITING 10 SECONDS BEFORE CONTINUING."
+      echo "KILL SYSTEM NOW IF YOU DO NOT TRUST THIS HEADER."
+      sleep 7
+      echo "3..."
+      sleep 1
+      echo "2..."
+      sleep 1
+      echo "1..."
+      sleep 1
     fi
     sleep 2
-fi
+  fi
+  if [ -f "$HEADERFILE" ]; then rm "$HEADERFILE"; fi
+done
 
 # Get Mortar key.
 tpm_nvread -i "$TPMINDEX" -f /tmp/mortar.key >/dev/null
@@ -52,12 +52,22 @@ tcsd && sleep 1
 tpm_nvread -i "$TPMINDEX" -s 0 >> /dev/null
 
 # Decrypt disk.
-if cryptsetup luksOpen $CRYPTDEV $CRYPTNAME --key-file /tmp/mortar.key; then
-    echo -e "TPM VALIDATION SUCCEEDED.\n\nI found $CRYPTNAME."
-    rm /tmp/mortar.key
-    if [ -f /tmp/mortar.key ]; then echo "FAILED TO REMOVE KEYFILE!"; fi
-    sleep 2
-else
-    echo "TPM VALIDATION FAILED."
+for CRYPTPAIR in $CRYPTPAIRS; do 
+  CRYPTNAME=${CRYPTPAIR%:*}
+  CRYPTDEV=${CRYPTPAIR#*:}
+  # Test if the disk is already unlocked.
+  if [ -e /dev/mapper/"$CRYPTNAME" ]; then
+    echo "skipping $CTYPTNAME as it already exists"
     sleep 3
-fi
+  else
+    if cryptsetup luksOpen $CRYPTDEV $CRYPTNAME --key-file /tmp/mortar.key; then
+      echo "opened $CRYPTNAME"
+    else
+      echo "could't open $CRYPTNAME"
+      sleep 3
+    fi
+  fi
+done
+sleep 2
+rm /tmp/mortar.key
+if [ -f /tmp/mortar.key ]; then echo "FAILED TO REMOVE KEYFILE!"; fi

--- a/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
+++ b/res/debian/tpm1.2/initramfs-tools/scripts/local-top/mortar
@@ -47,10 +47,10 @@ done
 
 # Get Mortar key.
 if tpm_nvread -i "$TPMINDEX" -f /tmp/mortar.key >/dev/null; then
- echo -e "TPM VALIDATION SUCCEEDED.\n\n"
+  echo -e "TPM VALIDATION SUCCEEDED.\n\n"
 else
- echo -e "TPM VALIDATION FAILED.\n\n"
- sleep 3
+  echo -e "TPM VALIDATION FAILED.\n\n"
+  sleep 3
 fi
 
 # Disable future key fetches.

--- a/res/debian/tpm1.2/install.sh
+++ b/res/debian/tpm1.2/install.sh
@@ -12,7 +12,7 @@ for CRYPTNAME in $CRYPTNAMES; do CRYPTPAIRS="$CRYPTNAME:$(cryptnametodevice $CRY
 sed -i -e "/^CRYPTPAIRS=.*/{s//CRYPTPAIRS=\"$CRYPTPAIRS\"/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^SLOT=.*/{s//SLOT=$SLOT/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^TPMINDEX=.*/{s//TPMINDEX=$TPMINDEX/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
-sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
+sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=\"$HEADERSHA256\"/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^HEADERFILE=.*/{s##HEADERFILE=\"$HEADERFILE\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 
 update-initramfs -u

--- a/res/debian/tpm1.2/install.sh
+++ b/res/debian/tpm1.2/install.sh
@@ -8,8 +8,7 @@ cp -r kernel /etc/
 cp -r initramfs-tools /etc/
 INITRAMFSSCRIPTFILE='/etc/initramfs-tools/scripts/local-top/mortar'
 source /etc/mortar/mortar.env
-sed -i -e "/^CRYPTDEV=.*/{s##CRYPTDEV=\"$CRYPTDEV\"#;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
-sed -i -e "/^CRYPTNAME=.*/{s//CRYPTNAME=$CRYPTNAME/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
+for CRYPTNAME in $CRYPTNAMES; do CRYPTPAIRS="$CRYPTNAME:$(cryptnametodevice $CRYPTNAME) $CRYPTPAIRS"; done
 sed -i -e "/^SLOT=.*/{s//SLOT=$SLOT/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^TPMINDEX=.*/{s//TPMINDEX=$TPMINDEX/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"

--- a/res/debian/tpm1.2/install.sh
+++ b/res/debian/tpm1.2/install.sh
@@ -9,6 +9,7 @@ cp -r initramfs-tools /etc/
 INITRAMFSSCRIPTFILE='/etc/initramfs-tools/scripts/local-top/mortar'
 source /etc/mortar/mortar.env
 for CRYPTNAME in $CRYPTNAMES; do CRYPTPAIRS="$CRYPTNAME:$(cryptnametodevice $CRYPTNAME) $CRYPTPAIRS"; done
+sed -i -e "/^CRYPTPAIRS=.*/{s//CRYPTPAIRS=\"$CRYPTPAIRS\"/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^SLOT=.*/{s//SLOT=$SLOT/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^TPMINDEX=.*/{s//TPMINDEX=$TPMINDEX/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"
 sed -i -e "/^HEADERSHA256=.*/{s//HEADERSHA256=$HEADERSHA256/;:a" -e '$!N;$!b' -e '}' "$INITRAMFSSCRIPTFILE"


### PR DESCRIPTION
I have adapted mortar to be able to decrypt two devices for a dm-raid/btrfs configuration. 

This is just a proof of concept. I'm running Debian on some older PC with TPM 1.2 only. So I extended mortar only for debian and TPM 1.2 and it works so far. 

For this reason this is a draft pull request for discussion and not for direct inclusion!

I'm using btrfs on two luks devices but using some dm-raid/lvm configuration would be the same. 

The main visible change in mortar.env is: removing CRYPTDEV and CRYPTNAME variables in favor of a CRYPTNAMES variable. CRYPTNAMES is a list of crypt device names from crypttab. See mortar.env and code changes for further information. This eases configuration a little and makes UUID=xxx devices possible. 