### PR TITLE
Add systemd-boot

### DIFF
--- a/res/debian/prereqs.sh
+++ b/res/debian/prereqs.sh
@@ -2,6 +2,7 @@ apt-get update
 apt-get install \
         binutils \
         efitools \
+        systemd-boot \
         uuid-runtime
 
 echo "Installed Debian dependencies."


### PR DESCRIPTION
Seems to be required at least for Debian 12 presently or mortar gives errors (unfortunately did not log them, will try to get them when I provision another one for evaluation)