### PR TITLE
Correcting annotation typos

### DIFF
--- a/3-tpm1.2-prepluksandinstallhooks.sh
+++ b/3-tpm1.2-prepluksandinstallhooks.sh
@@ -15,7 +15,7 @@ if [ -d tmpramfs ]; then
 	rm -rf tmpramfs
 fi
 
-#Create tpmramfs for generated mortar key and read user luks password to file.
+#Create tmpramfs for generated mortar key and read user luks password to file.
 if mkdir tmpramfs && mount tmpfs -t tmpfs -o size=1M,noexec,nosuid tmpramfs; then
 	echo "Created tmpramfs for storing the key."
 	trap "if [ -f tmpramfs/user.key ]; then rm -f tmpramfs/user.key; fi" EXIT


### PR DESCRIPTION
When referring to the code below, it seems natural that `tmprams` instead of `tpmrams` in the annotation.
Is my opinion correct?